### PR TITLE
Manipulating Image Save Rate More Easily

### DIFF
--- a/program_settings.txt
+++ b/program_settings.txt
@@ -2,4 +2,6 @@ exposure 10000
 analogGain 400
 preampGain -3
 blackLevel 0
-save_images 0
+save_images 1
+max_save_threads 5
+mod_save 1


### PR DESCRIPTION
This PR allows the rate at which images are saved to be more easily controlled by the user by making the following changes:
1. A new variable, max_save_threads, is defined that controls how many threads can be opened for saving.  The user must ensure that this is less than the macro MAX_THREADS in display.cpp.
2. A new variable, mod_save, replaces the use of the macro MOD_SAVE and is set in program_settings.txt.  This variable defines ```n``` where every ```n```th image is saved.  If not set, it defaults to MOD_SAVE.
3. Milliseconds are added to the timestamp used in defining the save filenames.  This ensures files are not overwritten if more than one is saved per second.