### PR TITLE
Closed file at end of read_settings().

### DIFF
--- a/display.cpp
+++ b/display.cpp
@@ -787,6 +787,7 @@ void read_settings(void) {
         printf("Can't open input file program_settings.txt!\n");
         printf("Default camera settings are (%" SCNu16 " %" SCNu16 " %" SCNd16 " %i)\n", settings.exposure, settings.analogGain, settings.preampGain, settings.blackLevel);
     }
+    fclose(file_ptr);
 }
 
 void *ImageSaveThread(void *threadargs)

--- a/display.cpp
+++ b/display.cpp
@@ -777,7 +777,12 @@ void read_settings(void) {
                     }
                     break;
                 case 6:
+		  if (value < 2) {
+		    printf("mod_save must be > 1.  Setting to 2.");
+		    mod_save = 2;
+		  } else {
                     mod_save = value;
+		  }
                 default:
                     break;
             }

--- a/program_settings.txt
+++ b/program_settings.txt
@@ -2,6 +2,6 @@ exposure 10000
 analogGain 400
 preampGain -3
 blackLevel 0
-save_images 1
+save_images false
 max_save_threads 5
-mod_save 1
+mod_save 10


### PR DESCRIPTION
Puts close command back in at end of read_settings which was erroneously deleted in last PR.