### PR TITLE
Explicitly Set Camera's ExposureMode to Timed

### DIFF
--- a/display.cpp
+++ b/display.cpp
@@ -396,6 +396,7 @@ void *CameraThread( void * threadargs)
                         // set camera settings
                         PvResult outcome;
                         lDeviceParams->SetBooleanValue("ProgFrameTimeEnable", false);
+                        outcome = lDeviceParams->SetEnumValue("ExposureMode", "Timed");
                         outcome = lDeviceParams->SetIntegerValue("ExposureTimeRaw", settings.exposure);
                         outcome = lDeviceParams->SetIntegerValue("GainRaw", settings.analogGain);
 

--- a/display.cpp
+++ b/display.cpp
@@ -787,6 +787,7 @@ void read_settings(void) {
         printf("Can't open input file program_settings.txt!\n");
         printf("Default camera settings are (%" SCNu16 " %" SCNu16 " %" SCNd16 " %i)\n", settings.exposure, settings.analogGain, settings.preampGain, settings.blackLevel);
     }
+    fclose(file_ptr);
 }
 
 void *ImageSaveThread(void *threadargs)

--- a/program_settings.txt
+++ b/program_settings.txt
@@ -2,6 +2,6 @@ exposure 10000
 analogGain 400
 preampGain -3
 blackLevel 0
-save_images 1
+save_images false
 max_save_threads 5
-mod_save 1
+mod_save 10


### PR DESCRIPTION
This PR sets the camera's ```ExposureMode``` in the ```*CameraThread``` function to ```"Timed"```.  Without this, the ```ExposureMode``` could be set to ```Off``` in which case the exposure time set the the ```program_settings.txt``` file cannot be implemented.