### PR TITLE
Enable Print Statements To Be Sent To a File

### DIFF
--- a/display.cpp
+++ b/display.cpp
@@ -497,13 +497,18 @@ void *CameraThread( void * threadargs)
                         }
                         frameCount++;
                     }
-                    fprintf(print_file_ptr, "\n %c BlockID: %016llX W: %i H: %i %.01f FPS %.01f Mb/s\r",
-                           lDoodle[ lDoodleIndex ],
-                           lBuffer->GetBlockID(),
-                           lWidth,
-                           lHeight,
-                           lFrameRateVal,
-                           lBandwidthVal / 1000000.0 );
+                    char block_message[255];
+                    char timestamp[TIMESTAMP_LENGTH];
+                    writeCurrentUT(timestamp);
+                    sprintf(block_message, "\n %c BlockID: %016llX W: %i H: %i %.01f FPS %.01f Mb/s at %s\r\n",
+                            lDoodle[ lDoodleIndex ],
+                            lBuffer->GetBlockID(),
+                            lWidth,
+                            lHeight,
+                            lFrameRateVal,
+                            lBandwidthVal / 1000000.0,
+                            timestamp);
+                    fprintf(print_file_ptr, block_message);
                 // We have an image - do some processing (...) and VERY IMPORTANT,
                 // release the buffer back to the pipeline
                 }
@@ -849,6 +854,7 @@ int main (int argc, char **argv) {
       sprintf(print_filename, "FOXSI_SAAS_print_output_%s.txt", timestamp);
       print_filename[128 - 1] = '\0';
       print_file_ptr = fopen(print_filename, "w");
+      fprintf(print_file_ptr, "Created print statement file, %s, at %s", print_filename, timestamp);
     }
 
     // to catch a Ctrl-C or termination signal and clean up

--- a/display.cpp
+++ b/display.cpp
@@ -566,7 +566,9 @@ void sig_handler(int signum)
 void start_thread(void *(*routine) (void *), const Thread_data *tdata)
 {
     if (*(*routine) == ImageSaveThread) {
-        fprintf(print_file_ptr, "Incrementing save_threads_count.\n");
+        char thread_message[100];
+        sprintf(thread_message, "Incrementing save_threads_count.  Was %u.  Now %u\n", save_threads_count, save_threads_count+1);
+        fprintf(print_file_ptr, "%s", thread_message);
         save_threads_count++;
     }
 
@@ -597,7 +599,8 @@ void start_thread(void *(*routine) (void *), const Thread_data *tdata)
     pthread_mutex_unlock(&mutexStartThread);
 
     if (*(*routine) == ImageSaveThread) {
-        fprintf(print_file_ptr, "Decrementing save_threads_count.\n");
+        sprintf(thread_message, "Decrementing save_threads_count. Was %u.  Now %u.\n", save_threads_count, save_threads_count-1);
+        fprintf(print_file_ptr, "%s", thread_message);
         save_threads_count--; 
     }
 

--- a/display.cpp
+++ b/display.cpp
@@ -706,8 +706,10 @@ void gl_reshape (int w, int h) {
 void keyboard (unsigned char key, int x, int y) {
     if (key=='q')
     {
-        // quite the program
+        // Quit the program.
         printf("Quitting and cleaning up.\n");
+        fflush(print_file_ptr);
+        fclose(print_file_ptr);
         glutLeaveGameMode(); //set the resolution how it was
         kill_all_threads();
         pthread_mutex_destroy(&mutexStartThread);

--- a/display.cpp
+++ b/display.cpp
@@ -2,6 +2,7 @@
 #define SAVE_LOCATION1 "/mnt/SAAS/images/" //Save locations for FITS files
 #define MOD_SAVE 30
 #define TIMESTAMP_LENGTH       19
+#define PRINT_TO_FILE true // Default for whether print statements are sent to screen or file.
 
 #define MAX_THREADS            10
 #define MAX_SAVE_THREADS       4
@@ -66,8 +67,8 @@ unsigned int max_save_threads = MAX_SAVE_THREADS;
 unsigned int save_threads_count = 0;
 unsigned int mod_save = MOD_SAVE;
 
-// file pointer
-FILE *file_ptr = NULL;
+FILE* file_ptr = NULL; // Pointer for general files.
+static FILE* print_file_ptr = NULL; // Pointer to where print statements should be sent.
 
 char message[100] = "Starting Up";
 int cameraID = 0;
@@ -189,8 +190,7 @@ void framerate(void){
     if (t - t0 >= 5.0) {
         GLfloat seconds = t - t0;
         GLfloat fps = frames / seconds;
-        printf("%d frames in %3.1f seconds = %6.3f FPS\n", frames, seconds,
-               fps);
+        fprintf(print_file_ptr, "%d frames in %3.1f seconds = %6.3f FPS\n", frames, seconds, fps);
         t0 = t;
         frames = 0;
     }
@@ -837,6 +837,18 @@ void *ImageSaveThread(void *threadargs)
 }
 
 int main (int argc, char **argv) {
+    // Set where print statements should sent: screen or file.
+    if (PRINT_TO_FILE == false) {
+      print_file_ptr = stdout;
+    } else {
+      char print_filename[128];
+      char timestamp[TIMESTAMP_LENGTH];
+      writeCurrentUT(timestamp);
+      sprintf(print_filename, "FOXSI_SAAS_print_output_%s.txt", timestamp);
+      print_filename[128 - 1] = '\0';
+      print_file_ptr = fopen(print_filename, "w");
+    }
+
     // to catch a Ctrl-C or termination signal and clean up
     signal(SIGINT, &sig_handler);
     signal(SIGTERM, &sig_handler);

--- a/program_settings.txt
+++ b/program_settings.txt
@@ -2,6 +2,6 @@ exposure 10000
 analogGain 400
 preampGain -3
 blackLevel 0
-save_images false
-max_save_threads 5
-mod_save 10
+save_images 1
+max_save_threads 2
+mod_save 1


### PR DESCRIPTION
This PR sends print statements from the display software to a file rather than the screen.  This makes its easier to recover the log since the prompt cannot be viewed while the display software is running.  This is especially true when the software crashes.