### PR TITLE
Platescale and target center correction

### DIFF
--- a/display.cpp
+++ b/display.cpp
@@ -54,7 +54,7 @@
 // width and height of IMPERX Camera frame
 static float width = NUM_XPIXELS;
 static float height = NUM_YPIXELS;
-static float arcsec_to_pixel = 3.1;   // the plate scale
+static float arcsec_to_pixel = 3.47;   // the plate scale
 long int frameCount = 0;
 long int saveCount = 0;  // counter for the number of images saved to disk
 float camera_temperature = 0.0;

--- a/display.cpp
+++ b/display.cpp
@@ -653,8 +653,8 @@ void gl_display (void) {
 
     // X - line
 	glBegin(GL_LINES);
-    glVertex2f(0.0f, NUM_YPIXELS - calib_center_y);
-    glVertex2f(width, NUM_YPIXELS - calib_center_y);
+    glVertex2f(0.0f, calib_center_y);
+    glVertex2f(width, calib_center_y);
     glEnd();
 
     // Y - line
@@ -665,11 +665,11 @@ void gl_display (void) {
 
     // Sun is 32 arcminutes across (radius of 16 arcminutes)
     // half a Sun
-    gl_draw_circle(calib_center_x, NUM_YPIXELS - calib_center_y, 8*60 / arcsec_to_pixel, NUM_CIRCLE_SEGMENTS);
+    gl_draw_circle(calib_center_x, calib_center_y, 8*60 / arcsec_to_pixel, NUM_CIRCLE_SEGMENTS);
     // full Sun
-    gl_draw_circle(calib_center_x, NUM_YPIXELS - calib_center_y, 16*60 / arcsec_to_pixel, NUM_CIRCLE_SEGMENTS);
+    gl_draw_circle(calib_center_x, calib_center_y, 16*60 / arcsec_to_pixel, NUM_CIRCLE_SEGMENTS);
     // 1.5 Sun
-    gl_draw_circle(calib_center_x, NUM_YPIXELS - calib_center_y, 24*60 / arcsec_to_pixel, NUM_CIRCLE_SEGMENTS);
+    gl_draw_circle(calib_center_x, calib_center_y, 24*60 / arcsec_to_pixel, NUM_CIRCLE_SEGMENTS);
 
     for (int i = 0; i < 48; i++) {
         glBegin(GL_LINES);
@@ -687,11 +687,11 @@ void gl_display (void) {
     for (int i = 0; i < 48; i++) {
         glBegin(GL_LINES);
         if (i < 24) {
-            glVertex2f(calib_center_x + i * 60 / arcsec_to_pixel, NUM_YPIXELS - calib_center_y - 10);
-            glVertex2f(calib_center_x + i * 60 / arcsec_to_pixel, NUM_YPIXELS - calib_center_y + 10);
+            glVertex2f(calib_center_x + i * 60 / arcsec_to_pixel, calib_center_y - 10);
+            glVertex2f(calib_center_x + i * 60 / arcsec_to_pixel, calib_center_y + 10);
         } else {
-            glVertex2f(calib_center_x + (24 - i) * 60 / arcsec_to_pixel, NUM_YPIXELS - calib_center_y - 10);
-            glVertex2f(calib_center_x + (24 - i) * 60 / arcsec_to_pixel, NUM_YPIXELS - calib_center_y + 10);
+            glVertex2f(calib_center_x + (24 - i) * 60 / arcsec_to_pixel, calib_center_y - 10);
+            glVertex2f(calib_center_x + (24 - i) * 60 / arcsec_to_pixel, calib_center_y + 10);
         }
         glEnd();
     }


### PR DESCRIPTION
This PR does the following:
1. Changes the platescale to 3.47 arcsec based on WSMR heliostat measurements taken on 2018-07-19.
2. Changes the target location so it is centered on the values in calibrated_ccd_center, i.e. it does assumes the values in this file are such that the 0 on the y-axis is at the top.